### PR TITLE
ENH: allow matplotlib colormaps as pal

### DIFF
--- a/legendgram/legendgram.py
+++ b/legendgram/legendgram.py
@@ -1,6 +1,10 @@
 from .util import make_location as _make_location
 import numpy as np
 
+from matplotlib.colors import Colormap
+from palettable.palette import Palette
+
+
 def legendgram(f, ax, y, breaks, pal, bins=50, clip=None,
                loc = 'lower left', legend_size=(.27,.2),
                frameon=False, tick_params = None):
@@ -17,7 +21,7 @@ def legendgram(f, ax, y, breaks, pal, bins=50, clip=None,
     breaks      : list
                   Sequence with breaks for each class (i.e. boundary values
                   for colors)
-    pal         : palettable colormap
+    pal         : palettable colormap or matplotlib colormap
     clip        : tuple
                   [Optional. Default=None] If a tuple, clips the X
                   axis of the histogram to the bounds provided.
@@ -36,18 +40,19 @@ def legendgram(f, ax, y, breaks, pal, bins=50, clip=None,
     axis containing the legendgram.
     '''
     k = len(breaks)
-    # assert k == pal.number, "provided number of classes does not match number of colors in palette."
     histpos = _make_location(ax, loc, legend_size=legend_size)
-
     histax = f.add_axes(histpos)
     N, bins, patches = histax.hist(y, bins=bins, color='0.1')
     #---
-    try:
+    if isinstance(pal, Palette):
+        assert k == pal.number, "provided number of classes does not match number of colors in palette."
         pl = pal.get_mpl_colormap()
-    except:
+    elif isinstance(pal, Colormap):
         pl = pal
+    else:
+        raise ValueError("pal needs to be either palettable colormap or matplotlib colormap, got {}".format(type(pal)))
     bucket_breaks = [0]+[np.searchsorted(bins, i) for i in breaks]
-    for c in range(k):
+    for c in range(k + 1):
         for b in range(bucket_breaks[c], bucket_breaks[c+1]):
             patches[b].set_facecolor(pl(c/k))
     #---

--- a/legendgram/legendgram.py
+++ b/legendgram/legendgram.py
@@ -52,7 +52,7 @@ def legendgram(f, ax, y, breaks, pal, bins=50, clip=None,
     else:
         raise ValueError("pal needs to be either palettable colormap or matplotlib colormap, got {}".format(type(pal)))
     bucket_breaks = [0]+[np.searchsorted(bins, i) for i in breaks]
-    for c in range(k + 1):
+    for c in range(k):
         for b in range(bucket_breaks[c], bucket_breaks[c+1]):
             patches[b].set_facecolor(pl(c/k))
     #---

--- a/legendgram/legendgram.py
+++ b/legendgram/legendgram.py
@@ -7,7 +7,7 @@ def legendgram(f, ax, y, breaks, pal, bins=50, clip=None,
     '''
     Add a histogram in a choropleth with colors aligned with map
     ...
-    
+
     Arguments
     ---------
     f           : Figure
@@ -33,16 +33,19 @@ def legendgram(f, ax, y, breaks, pal, bins=50, clip=None,
 
     Returns
     -------
-    axis containing the legendgram. 
+    axis containing the legendgram.
     '''
     k = len(breaks)
-    assert k == pal.number, "provided number of classes does not match number of colors in palette."
+    # assert k == pal.number, "provided number of classes does not match number of colors in palette."
     histpos = _make_location(ax, loc, legend_size=legend_size)
 
     histax = f.add_axes(histpos)
     N, bins, patches = histax.hist(y, bins=bins, color='0.1')
     #---
-    pl = pal.get_mpl_colormap()
+    try:
+        pl = pal.get_mpl_colormap()
+    except:
+        pl = pal
     bucket_breaks = [0]+[np.searchsorted(bins, i) for i in breaks]
     for c in range(k):
         for b in range(bucket_breaks[c], bucket_breaks[c+1]):

--- a/legendgram/test_legendgram.py
+++ b/legendgram/test_legendgram.py
@@ -2,6 +2,7 @@ import unittest as ut
 import matplotlib as mpl
 mpl.use("pdf")
 import matplotlib.pyplot as plt
+from pysal.contrib.viz.mapping import geoplot
 import pysal as ps
 from palettable import matplotlib as mplpal
 from .util import inv_lut

--- a/legendgram/test_legendgram.py
+++ b/legendgram/test_legendgram.py
@@ -2,7 +2,6 @@ import unittest as ut
 import matplotlib as mpl
 mpl.use("pdf")
 import matplotlib.pyplot as plt
-from pysal.contrib.viz.mapping import geoplot
 import pysal as ps
 from palettable import matplotlib as mplpal
 from .util import inv_lut
@@ -17,6 +16,7 @@ class Test_Legendgram(ut.TestCase):
         self.k = 10
         self.breaks = ps.Quantiles(self.data[self.test_attribute].values, k=self.k).bins
         self.pal = mplpal.Inferno_10
+        self.cmap = mplpal.Inferno_10.get_mpl_colormap()
 
     def genframe(self):
         f,ax = plt.subplots()
@@ -26,23 +26,23 @@ class Test_Legendgram(ut.TestCase):
 
     def test_call(self):
         f,ax = self.genframe()
-        aout = legendgram(f,ax, self.data[self.test_attribute].values, 
+        aout = legendgram(f,ax, self.data[self.test_attribute].values,
                           self.breaks, mplpal.Inferno_10)
         plt.close(f)
 
     def test_positioning(self):
         """
-        Check that changing the locstring changes the location of the plot. 
-        Also, check that all strings & ints are able to be used. 
+        Check that changing the locstring changes the location of the plot.
+        Also, check that all strings & ints are able to be used.
         """
 
         bboxes = []
         for i in range(1,11):
             f,ax = self.genframe()
-            aout = legendgram(f,ax, self.data[self.test_attribute].values, 
+            aout = legendgram(f,ax, self.data[self.test_attribute].values,
                               self.breaks, mplpal.Inferno_10, loc=i)
             f2,ax2 = self.genframe()
-            aout2 = legendgram(f2,ax2, self.data[self.test_attribute].values, 
+            aout2 = legendgram(f2,ax2, self.data[self.test_attribute].values,
                               self.breaks, mplpal.Inferno_10, loc=inv_lut[i])
             print(i,inv_lut[i])
             bbox = aout.get_position()
@@ -55,7 +55,7 @@ class Test_Legendgram(ut.TestCase):
         for i in range(len(bboxes)-1):
             self.assertTrue(bboxes[i].bounds != bboxes[i+1].bounds)
         f,ax = self.genframe()
-        aout = legendgram(f,ax, self.data[self.test_attribute].values, 
+        aout = legendgram(f,ax, self.data[self.test_attribute].values,
                               self.breaks, mplpal.Inferno_10, loc=0)
         bestbbox = aout.get_position()
         print(bestbbox.bounds, bboxes[2].bounds)
@@ -97,3 +97,15 @@ class Test_Legendgram(ut.TestCase):
         with self.assertRaises(AssertionError):
             aout = legendgram(f,ax, self.data[self.test_attribute].values,
                               self.breaks, mplpal.Inferno_12)
+
+    def test_matplotlib_cmap(self):
+        f,ax = self.genframe()
+        aout = legendgram(f,ax, self.data[self.test_attribute].values,
+                          self.breaks, self.cmap)
+        plt.close(f)
+
+    def test_pal_typeerror(self):
+        f,ax = self.genframe()
+        with self.assertRaises(ValueError):
+            aout = legendgram(f,ax, self.data[self.test_attribute].values,
+                              self.breaks, 'pal')


### PR DESCRIPTION
Allow matplotlib colormaps to be used directly as `pal`. Closes #9 

@ljwolf Note that tests are apparently broken due to changes in Pysal. We may use geopandas `naturalearth_lowres` as a test data instead. That way you don't need whole PySAL to be installed. I have just mimicked your tests, so there is no real check that color is correctly assigned.